### PR TITLE
fix: fix resource group and location fallbacks

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,11 +1,7 @@
 # managed instance
 resource "azurerm_mssql_managed_instance" "sql" {
-  resource_group_name = coalesce(try(var.config.resource_group, null), var.resource_group
-  )
-
-  location = coalesce(try(var.config.location, null), var.location
-  )
-
+  resource_group_name            = coalesce(try(var.config.resource_group, null), var.resource_group)
+  location                       = coalesce(try(var.config.location, null), var.location)
   name                           = var.config.name
   sku_name                       = var.config.sku_name
   license_type                   = try(var.config.license_type, "LicenseIncluded")

--- a/main.tf
+++ b/main.tf
@@ -1,11 +1,9 @@
 # managed instance
 resource "azurerm_mssql_managed_instance" "sql" {
-  resource_group_name = coalesce(
-    var.config.resource_group, var.resource_group
+  resource_group_name = coalesce(try(var.config.resource_group, null), var.resource_group
   )
 
-  location = coalesce(
-    var.config.location, var.location
+  location = coalesce(try(var.config.location, null), var.location
   )
 
   name                           = var.config.name


### PR DESCRIPTION
## Description

when the global vars resource_group and location are set - as described in the default example - these are not correctly set. The coalesce function errors as var.config.resource_group and var.config.location are not set within the object but as global vars in var.resource_group and location. For this a try function which returns a null value is introduced, so that the coalesce function then can continue to the next argument, being the global vars in this case. 


## PR Checklist

- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking change (not backwards compatible with previous releases)


## Related Issue(s)
Fixes #7 
